### PR TITLE
Call pthread_exit() instead of return in pthread start functions

### DIFF
--- a/threadpool_pthread.c
+++ b/threadpool_pthread.c
@@ -159,7 +159,7 @@ static void *threadpool_do_work(void *arg) {
 
     pthread_cond_signal(&threadpool->lazy_cond);
     pthread_mutex_unlock(&threadpool->queue_mutex);
-    return NULL;
+    pthread_exit(NULL);
 }
 
 static void threadpool_create_thread_on_demand(threadpool_s *threadpool) {


### PR DESCRIPTION
Otherwise thread-cancellation clean-up handlers are not called. See man pthread_cleanup_push(3).

> 2. When a thread terminates by calling pthread_exit(3), all clean-up
>    handlers are executed as described in the preceding point.  (Clean-up
>    handlers are not called if the thread terminates by performing a return
>    from the thread start function.)