### PR TITLE
Add test case for the empty proxy bypass list configured

### DIFF
--- a/test/test_config.cc
+++ b/test/test_config.cc
@@ -10,29 +10,30 @@
 TEST(config, override_auto_config_url) {
     proxy_config_set_auto_config_url_override("http://127.0.0.1:8000/wpad.dat");
     char *auto_config_url = proxy_config_get_auto_config_url();
-    EXPECT_NE(auto_config_url, nullptr);
-    if (auto_config_url) {
-        EXPECT_STREQ(auto_config_url, "http://127.0.0.1:8000/wpad.dat");
-        free(auto_config_url);
-    }
+    ASSERT_NE(auto_config_url, nullptr);
+    EXPECT_STREQ(auto_config_url, "http://127.0.0.1:8000/wpad.dat");
+    free(auto_config_url);
 }
 
 TEST(config, override_proxy) {
     proxy_config_set_proxy_override("http://127.0.0.1:8000/");
     char *proxy = proxy_config_get_proxy("http");
-    EXPECT_NE(proxy, nullptr);
-    if (proxy) {
-        EXPECT_STREQ(proxy, "http://127.0.0.1:8000/");
-        free(proxy);
-    }
+    ASSERT_NE(proxy, nullptr);
+    EXPECT_STREQ(proxy, "http://127.0.0.1:8000/");
+    free(proxy);
 }
 
 TEST(config, override_bypass_list) {
     proxy_config_set_bypass_list_override("<local>");
     char *bypass_list = proxy_config_get_bypass_list();
-    EXPECT_NE(bypass_list, nullptr);
-    if (bypass_list) {
-        EXPECT_STREQ(bypass_list, "<local>");
-        free(bypass_list);
-    }
+    ASSERT_NE(bypass_list, nullptr);
+    EXPECT_STREQ(bypass_list, "<local>");
+    free(bypass_list);
+}
+
+TEST(config, override_bypass_list_with_empt_list) {
+    proxy_config_set_bypass_list_override("");
+    char *bypass_list = proxy_config_get_bypass_list();
+    EXPECT_EQ(bypass_list, nullptr);
+    free(bypass_list);  // In case the condition above is not met
 }


### PR DESCRIPTION
Simplify other config test cases with using predicate assertions instead of expectations.

This should fix the degrading coverage report in #13
| [Impacted Files](https://codecov.io/gh/nmoinvaz/proxyres/pull/13?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=Nathan+Moinvaziri) | Coverage Δ | |
|---|---|---|
| [config.c](https://codecov.io/gh/nmoinvaz/proxyres/pull/13?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=Nathan+Moinvaziri#diff-Y29uZmlnLmM=) | `56.09% <0.00%> (-1.22%)` | :arrow_down: |
