### PR TITLE
Always bypass localhost addresses when using manual proxy.

### DIFF
--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -162,11 +162,11 @@ bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url) {
     } else if ((proxy = proxy_config_get_proxy(url)) != NULL) {
         // Check to see if we need to bypass the proxy for the url
         bool should_bypass = false;
-        if ((bypass_list = proxy_config_get_bypass_list()) != NULL)
-            should_bypass = should_bypass_proxy(url, bypass_list);
+        bypass_list = proxy_config_get_bypass_list();
+        should_bypass = should_bypass_proxy(url, bypass_list);
         if (should_bypass) {
             // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list);
+            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
             proxy_resolver->list = strdup("direct://");
         } else {
             // Use proxy from settings

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -176,11 +176,11 @@ bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url) {
     if ((proxy = proxy_config_get_proxy(scheme)) != NULL) {
         // Check to see if we need to bypass the proxy for the url
         bool should_bypass = false;
-        if ((bypass_list = proxy_config_get_bypass_list()) != NULL)
-            should_bypass = should_bypass_proxy(url, bypass_list);
+        bypass_list = proxy_config_get_bypass_list();
+        should_bypass = should_bypass_proxy(url, bypass_list);
         if (should_bypass) {
             // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list);
+            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
             proxy_resolver->list = strdup("direct://");
         } else {
             // Use proxy from settings

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -195,11 +195,11 @@ bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url) {
     if ((proxy = proxy_config_get_proxy(scheme)) != NULL) {
         // Check to see if we need to bypass the proxy for the url
         bool should_bypass = false;
-        if ((bypass_list = proxy_config_get_bypass_list()) != NULL)
-            should_bypass = should_bypass_proxy(url, bypass_list);
+        bypass_list = proxy_config_get_bypass_list();
+        should_bypass = should_bypass_proxy(url, bypass_list);
         if (should_bypass) {
             // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list);
+            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
             proxy_resolver->list = strdup("direct://");
         } else {
             // Use proxy from settings

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -74,11 +74,11 @@ bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
     if ((proxy = proxy_config_get_proxy(scheme)) != NULL) {
         // Check to see if we need to bypass the proxy for the url
         bool should_bypass = false;
-        if ((bypass_list = proxy_config_get_bypass_list()) != NULL)
-            should_bypass = should_bypass_proxy(url, bypass_list);
+        bypass_list = proxy_config_get_bypass_list();
+        should_bypass = should_bypass_proxy(url, bypass_list);
         if (should_bypass) {
             // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list);
+            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
             proxy_resolver->list = strdup("direct://");
         } else {
             // Use proxy from settings

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -129,15 +129,18 @@ struct should_bypass_list_param {
     bool expected;
 
     friend std::ostream &operator<<(std::ostream &os, const should_bypass_list_param &param) {
-        return os << "url: " << param.url << std::endl << "bypass list: " << param.bypass_list;
+        return os << "url: " << param.url << std::endl
+                  << "bypass list: " << (param.bypass_list ? param.bypass_list : "<null>");
     }
 };
 
 constexpr should_bypass_list_param should_bypass_list_tests[] = {
     // Bypass due to localhost hostname
     {"http://localhost/", "", true},
+    {"http://localhost/", nullptr, true},
     // Bypass due to localhost ip
     {"http://127.0.0.1/", "", true},
+    {"http://127.0.0.1/", nullptr, true},
     // Bypass due to <local> on simple hostnames
     {"http://apple/", "<local>", true},
     // Don't bypass due to <local> only applying to simple hostnames

--- a/test/test_util.cc
+++ b/test/test_util.cc
@@ -45,8 +45,7 @@ struct get_url_from_host_param {
     const char *expected;
 
     friend std::ostream &operator<<(std::ostream &os, const get_url_from_host_param &param) {
-        return os << "scheme: " << param.scheme << std::endl
-                  << "host: " << param.host;
+        return os << "scheme: " << param.scheme << std::endl << "host: " << param.host;
     }
 };
 
@@ -96,16 +95,16 @@ struct convert_proxy_list_to_uri_list_param {
 };
 
 constexpr convert_proxy_list_to_uri_list_param convert_proxy_list_to_uri_list_tests[] = {
-    {"DIRECT", NULL, "direct://"},
-    {"PROXY 127.0.0.1:80", NULL, "http://127.0.0.1:80"},
-    {"PROXY 127.0.0.1:8080", NULL, "http://127.0.0.1:8080"},
-    {"PROXY 127.0.0.1:443", NULL, "https://127.0.0.1:443"},
+    {"DIRECT", nullptr, "direct://"},
+    {"PROXY 127.0.0.1:80", nullptr, "http://127.0.0.1:80"},
+    {"PROXY 127.0.0.1:8080", nullptr, "http://127.0.0.1:8080"},
+    {"PROXY 127.0.0.1:443", nullptr, "https://127.0.0.1:443"},
     {"PROXY myproxy0.com:90", "http", "http://myproxy0.com:90"},
     {"PROXY myproxy1.com:90", "https", "https://myproxy1.com:90"},
-    {"HTTP myproxy1.com:80;SOCKS myproxy2.com:1080", NULL, "http://myproxy1.com:80,socks://myproxy2.com:1080"},
-    {"HTTP myproxy3.com:80;SOCKS myproxy4.com:1080;DIRECT", NULL,
+    {"HTTP myproxy1.com:80;SOCKS myproxy2.com:1080", nullptr, "http://myproxy1.com:80,socks://myproxy2.com:1080"},
+    {"HTTP myproxy3.com:80;SOCKS myproxy4.com:1080;DIRECT", nullptr,
      "http://myproxy3.com:80,socks://myproxy4.com:1080,direct://"},
-    {"PROXY proxy1.example.com:80; PROXY proxy2.example.com:8080", NULL,
+    {"PROXY proxy1.example.com:80; PROXY proxy2.example.com:8080", nullptr,
      "http://proxy1.example.com:80,http://proxy2.example.com:8080"},
 };
 

--- a/util.c
+++ b/util.c
@@ -425,7 +425,7 @@ bool should_bypass_proxy(const char *url, const char *bypass_list) {
     bool is_simple = false;
     bool should_bypass = false;
 
-    if (!url || !bypass_list)
+    if (!url)
         return true;
 
     // Chromium documentation for proxy bypass rules:
@@ -443,13 +443,16 @@ bool should_bypass_proxy(const char *url, const char *bypass_list) {
     if (strcmp(host, "127.0.0.1") == 0 || strcasecmp(host, "localhost") == 0)
         is_local = true;
 
-    // Check for simple hostnames
-    if (strchr(host, '.') == NULL)
-        is_simple = true;
-
     // By default don't allow localhost urls to go through proxy
     if (is_local)
         should_bypass = true;
+
+    if (!bypass_list)
+        return should_bypass;
+
+    // Check for simple hostnames
+    if (strchr(host, '.') == NULL)
+        is_simple = true;
 
     // Enumerate through each bypass expression in the bypass list
     const char *bypass_list_end = bypass_list + strlen(bypass_list);


### PR DESCRIPTION
Previously if the proxy bypass is not set, then localhost proxies would not be bypassed. This ignores whether or not the proxy bypass is set and still continues to check if the proxy needs to be bypassed for localhost addresses.