### PR TITLE
Don't return empty values in proxy_config functions.

### DIFF
--- a/config_gnome2.c
+++ b/config_gnome2.c
@@ -131,18 +131,20 @@ char *proxy_config_gnome2_get_bypass_list(void) {
     if (hosts) {
         // Enumerate the list to get the size of the bypass list
         g_proxy_config_gnome2.g_slist_foreach(hosts, gs_list_for_each_func, &enum_bypass);
-        enum_bypass.max_value++;
+        if (enum_bypass.max_value > 0) {
+            enum_bypass.max_value++;
 
-        // Allocate space for the bypass list
-        bypass_list = calloc(enum_bypass.max_value, sizeof(char));
-        if (bypass_list) {
-            enum_bypass.value = bypass_list;
+            // Allocate space for the bypass list
+            bypass_list = calloc(enum_bypass.max_value, sizeof(char));
+            if (bypass_list) {
+                enum_bypass.value = bypass_list;
 
-            // Enumerate the list to get the bypass list string
-            g_proxy_config_gnome2.g_slist_foreach(hosts, gs_list_for_each_func, &enum_bypass);
+                // Enumerate the list to get the bypass list string
+                g_proxy_config_gnome2.g_slist_foreach(hosts, gs_list_for_each_func, &enum_bypass);
 
-            // Remove the last separator
-            str_trim_end(bypass_list, ',');
+                // Remove the last separator
+                str_trim_end(bypass_list, ',');
+            }
         }
 
         g_proxy_config_gnome2.g_slist_free_full(hosts, g_proxy_config_gnome2.g_free);

--- a/config_mac.c
+++ b/config_mac.c
@@ -56,6 +56,12 @@ char *proxy_config_mac_get_auto_config_url(void) {
         }
     }
 
+    // Don't return empty url
+    if (url && !*url) {
+        free(url);
+        url = NULL;
+    }
+
     CFRelease(proxy_settings);
     return url;
 }
@@ -117,6 +123,12 @@ char *proxy_config_mac_get_proxy(const char *scheme) {
             int32_t proxy_len = strlen(proxy);
             snprintf(proxy + proxy_len, max_proxy - proxy_len, ":%" PRId64 "", port_number);
         }
+    }
+
+    // Don't return empty proxy
+    if (proxy && !*proxy) {
+        free(proxy);
+        proxy = NULL;
     }
 
     CFRelease(proxy_settings);
@@ -187,6 +199,12 @@ char *proxy_config_mac_get_bypass_list(void) {
         str_trim_end(bypass_list, ',');
 
 bypass_list_error:
+
+    // Don't return empty bypass list
+    if (bypass_list && !*bypass_list) {
+        free(bypass_list);
+        bypass_list = NULL;
+    }
 
     CFRelease(proxy_settings);
     return bypass_list;


### PR DESCRIPTION
Some platforms such as Windows and Gnome already do this for most values and this extends it to the rest of the functions and platforms.