### PR TITLE
Revert "Check for empty string when setting proxy override settings."

### DIFF
--- a/config.c
+++ b/config.c
@@ -69,20 +69,20 @@ char *proxy_config_get_bypass_list(void) {
 void proxy_config_set_auto_config_url_override(const char *auto_config_url) {
     if (g_proxy_config.auto_config_url)
         free(g_proxy_config.auto_config_url);
-    g_proxy_config.auto_config_url = auto_config_url && *auto_config_url ? strdup(auto_config_url) : NULL;
+    g_proxy_config.auto_config_url = auto_config_url ? strdup(auto_config_url) : NULL;
     g_proxy_config.auto_discover_disable = auto_config_url != NULL;
 }
 
 void proxy_config_set_proxy_override(const char *proxy) {
     if (g_proxy_config.proxy)
         free(g_proxy_config.proxy);
-    g_proxy_config.proxy = proxy && *proxy ? strdup(proxy) : NULL;
+    g_proxy_config.proxy = proxy ? strdup(proxy) : NULL;
     g_proxy_config.auto_discover_disable = proxy != NULL;
 }
 
 void proxy_config_set_bypass_list_override(const char *bypass_list) {
     free(g_proxy_config.bypass_list);
-    g_proxy_config.bypass_list = bypass_list && *bypass_list ? strdup(bypass_list) : NULL;
+    g_proxy_config.bypass_list = bypass_list ? strdup(bypass_list) : NULL;
 }
 
 bool proxy_config_global_init(void) {


### PR DESCRIPTION
Reverts nmoinvaz/proxyres#23

Setting it to emtpy string should override it system settings.