### PR TITLE
Add proxy execute unit tests for file:// scheme.

### DIFF
--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -257,7 +257,8 @@ win8_resolve:
 
     if (error != ERROR_IO_PENDING) {
         proxy_resolver->error = error;
-        LOG_ERROR("Unable to get proxy for url %s (%" PRId32 ")", url, proxy_resolver->error);
+        if (error != ERROR_WINHTTP_UNRECOGNIZED_SCHEME)
+            LOG_ERROR("Unable to get proxy for url %s (%" PRId32 ")", url, proxy_resolver->error);
         goto win8_done;
     }
 

--- a/test/test_execute.cc
+++ b/test/test_execute.cc
@@ -64,7 +64,9 @@ constexpr execute_param execute_tests[] = {{"your-pc", "HTTP plain"},
                                            {"http://127.0.0.1/", "PROXY localhost:30"},
                                            {"http://simple.com/", "PROXY no-such-proxy:80"},
                                            {"http://example2.com/", "DIRECT"},
-                                           {"http://microsoft.com/test", "PROXY microsoft.com:80"}};
+                                           {"http://microsoft.com/test", "PROXY microsoft.com:80"},
+                                           {"file:///c:/test", NULL},
+                                           {"file:////home/test", NULL}};
 
 class execute : public ::testing::TestWithParam<execute_param> {};
 


### PR DESCRIPTION
Proxy execute should fail when trying to file the proxy for a scheme it doesn't recognize.