### PR TITLE
Fixed bug on Windows XP where auto-detection not working.

### DIFF
--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -87,7 +87,7 @@ bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
         goto winxp_done;
     }
 
-    if (proxy_config_get_auto_discover()) {
+    if (!proxy_config_get_auto_discover()) {
         // Don't do automatic proxy detection
         goto winxp_done;
     }


### PR DESCRIPTION
This code should be like it is in Windows 8 code.