### PR TITLE
Split getting system proxy configuration from auto-proxy discovery.

### DIFF
--- a/config_kde.c
+++ b/config_kde.c
@@ -117,7 +117,7 @@ bool proxy_config_kde_global_init(void) {
         break;
     }
 
-    // Check to see if config file exists
+    // Check if config file exists
     if (access(config_path, F_OK) == -1)
         return false;
 

--- a/config_mac.c
+++ b/config_mac.c
@@ -41,7 +41,7 @@ char *proxy_config_mac_get_auto_config_url(void) {
     if (!proxy_settings)
         return NULL;
 
-    // Check to see if auto-config url is enabled
+    // Check if auto-config url is enabled
     if (get_cf_dictionary_bool(proxy_settings, kCFNetworkProxiesProxyAutoConfigEnable)) {
         // Get the auto-config url
         CFStringRef auto_config_url = CFDictionaryGetValue(proxy_settings, kCFNetworkProxiesProxyAutoConfigURLString);

--- a/config_mac.c
+++ b/config_mac.c
@@ -26,7 +26,7 @@ bool proxy_config_mac_get_auto_discover(void) {
     if (!proxy_settings)
         return false;
 
-    // Get whether or not auto discovery is enabled
+    // Get whether or not auto-discovery is enabled
     if (get_cf_dictionary_bool(proxy_settings, kCFNetworkProxiesProxyAutoDiscoveryEnable))
         auto_discover = true;
 

--- a/resolver.c
+++ b/resolver.c
@@ -77,10 +77,10 @@ static bool proxy_resolver_get_proxies_for_url_from_system_config(void *ctx, con
         goto config_done;
     }
 
-    // Check to see if manually configured proxy is specified in system config
+    // Check if manually configured proxy is specified in system config
     proxy = proxy_config_get_proxy(scheme);
     if (proxy) {
-        // Check to see if we need to bypass the proxy for the url
+        // Check if we need to bypass the proxy for the url
         char *bypass_list = proxy_config_get_bypass_list();
         bool should_bypass = should_bypass_proxy(url, bypass_list);
         if (should_bypass) {

--- a/resolver.c
+++ b/resolver.c
@@ -69,7 +69,7 @@ bool proxy_resolver_get_proxies_for_url(void *ctx, const char *url) {
         return true;
 
     // Automatically discover proxy configuration asynchronously if supported, otherwise spool to thread pool
-    if (g_proxy_resolver.proxy_resolver_i->is_discover_async())
+    if (g_proxy_resolver.proxy_resolver_i->is_discover_async)
         return g_proxy_resolver.proxy_resolver_i->discover_proxies_for_url(proxy_resolver->base, url);
 
     free(proxy_resolver->url);
@@ -198,7 +198,7 @@ bool proxy_resolver_global_init(void) {
     }
 
     // No need to create thread pool since underlying implementation is already asynchronous
-    if (g_proxy_resolver.proxy_resolver_i->is_discover_async()) {
+    if (g_proxy_resolver.proxy_resolver_i->is_discover_async) {
         g_proxy_resolver.ref_count++;
         return true;
     }

--- a/resolver.c
+++ b/resolver.c
@@ -54,7 +54,7 @@ static void proxy_resolver_get_proxies_for_url_threadpool(void *arg) {
     proxy_resolver_s *proxy_resolver = (proxy_resolver_s *)arg;
     if (!proxy_resolver)
         return;
-    g_proxy_resolver.proxy_resolver_i->get_proxies_for_url(proxy_resolver->base, proxy_resolver->url);
+    g_proxy_resolver.proxy_resolver_i->discover_proxies_for_url(proxy_resolver->base, proxy_resolver->url);
 }
 
 bool proxy_resolver_get_proxies_for_url(void *ctx, const char *url) {
@@ -64,9 +64,13 @@ bool proxy_resolver_get_proxies_for_url(void *ctx, const char *url) {
 
     proxy_resolver->listp = NULL;
 
-    // Call get_proxies_for_url directly since the underlying interface is asynchronous
-    if (g_proxy_resolver.proxy_resolver_i->is_async())
-        return g_proxy_resolver.proxy_resolver_i->get_proxies_for_url(proxy_resolver->base, url);
+    // Use system proxy configuration if no auto-discovery mechanism is necessary
+    if (g_proxy_resolver.proxy_resolver_i->get_proxies_for_url(proxy_resolver->base, url))
+        return true;
+
+    // Automatically discover proxy configuration asynchronously if supported, otherwise spool to thread pool
+    if (g_proxy_resolver.proxy_resolver_i->is_discover_async())
+        return g_proxy_resolver.proxy_resolver_i->discover_proxies_for_url(proxy_resolver->base, url);
 
     free(proxy_resolver->url);
     proxy_resolver->url = strdup(url);
@@ -194,7 +198,7 @@ bool proxy_resolver_global_init(void) {
     }
 
     // No need to create thread pool since underlying implementation is already asynchronous
-    if (g_proxy_resolver.proxy_resolver_i->is_async()) {
+    if (g_proxy_resolver.proxy_resolver_i->is_discover_async()) {
         g_proxy_resolver.ref_count++;
         return true;
     }

--- a/resolver_gnome3.c
+++ b/resolver_gnome3.c
@@ -49,6 +49,13 @@ typedef struct proxy_resolver_gnome3_s {
     char *list;
 } proxy_resolver_gnome3_s;
 
+bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url) {
+    UNUSED(ctx);
+    UNUSED(url);
+    // All proxy resolution must go through gnome3 resolver
+    return false;
+}
+
 static void proxy_resolver_gnome3_delete_resolver(proxy_resolver_gnome3_s *proxy_resolver) {
     if (proxy_resolver->cancellable) {
         g_proxy_resolver_gnome3.g_object_unref(proxy_resolver->cancellable);
@@ -117,7 +124,7 @@ static bool proxy_resolver_gnome3_get_proxies(proxy_resolver_gnome3_s *proxy_res
     return true;
 }
 
-bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_gnome3_discover_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_gnome3_s *proxy_resolver = (proxy_resolver_gnome3_s *)ctx;
     GError *error = NULL;
     char **proxies = NULL;
@@ -203,7 +210,8 @@ bool proxy_resolver_gnome3_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_gnome3_is_async(void) {
+bool proxy_resolver_gnome3_is_discover_async(void) {
+    // discover_proxies_for_url should be spooled to another thread
     return false;
 }
 
@@ -266,13 +274,14 @@ bool proxy_resolver_gnome3_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_gnome3_i = {proxy_resolver_gnome3_get_proxies_for_url,
+                                                         proxy_resolver_gnome3_discover_proxies_for_url,
                                                          proxy_resolver_gnome3_get_list,
                                                          proxy_resolver_gnome3_get_error,
                                                          proxy_resolver_gnome3_wait,
                                                          proxy_resolver_gnome3_cancel,
                                                          proxy_resolver_gnome3_create,
                                                          proxy_resolver_gnome3_delete,
-                                                         proxy_resolver_gnome3_is_async,
+                                                         proxy_resolver_gnome3_is_discover_async,
                                                          proxy_resolver_gnome3_global_init,
                                                          proxy_resolver_gnome3_global_cleanup};
     return &proxy_resolver_gnome3_i;

--- a/resolver_gnome3.c
+++ b/resolver_gnome3.c
@@ -49,13 +49,6 @@ typedef struct proxy_resolver_gnome3_s {
     char *list;
 } proxy_resolver_gnome3_s;
 
-bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url) {
-    UNUSED(ctx);
-    UNUSED(url);
-    // All proxy resolution must go through gnome3 resolver
-    return false;
-}
-
 static void proxy_resolver_gnome3_delete_resolver(proxy_resolver_gnome3_s *proxy_resolver) {
     if (proxy_resolver->cancellable) {
         g_proxy_resolver_gnome3.g_object_unref(proxy_resolver->cancellable);
@@ -269,7 +262,6 @@ bool proxy_resolver_gnome3_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_gnome3_i = {
-        proxy_resolver_gnome3_get_proxies_for_url,
         proxy_resolver_gnome3_discover_proxies_for_url,
         proxy_resolver_gnome3_get_list,
         proxy_resolver_gnome3_get_error,
@@ -278,6 +270,7 @@ proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
         proxy_resolver_gnome3_create,
         proxy_resolver_gnome3_delete,
         false /* discover_proxies_for_url should be spooled to another thread */,
+        true /* discover_proxies_for_url takes into account system config */,
         proxy_resolver_gnome3_global_init,
         proxy_resolver_gnome3_global_cleanup};
     return &proxy_resolver_gnome3_i;

--- a/resolver_gnome3.c
+++ b/resolver_gnome3.c
@@ -269,8 +269,8 @@ proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
         proxy_resolver_gnome3_cancel,
         proxy_resolver_gnome3_create,
         proxy_resolver_gnome3_delete,
-        false /* get_proxies_for_url should be spooled to another thread */,
-        true /* get_proxies_for_url takes into account system config */,
+        false,  // get_proxies_for_url should be spooled to another thread
+        true,   // get_proxies_for_url takes into account system config
         proxy_resolver_gnome3_global_init,
         proxy_resolver_gnome3_global_cleanup};
     return &proxy_resolver_gnome3_i;

--- a/resolver_gnome3.c
+++ b/resolver_gnome3.c
@@ -210,11 +210,6 @@ bool proxy_resolver_gnome3_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_gnome3_is_discover_async(void) {
-    // discover_proxies_for_url should be spooled to another thread
-    return false;
-}
-
 bool proxy_resolver_gnome3_global_init(void) {
     g_proxy_resolver_gnome3.gio_module = dlopen("libgio-2.0.so.0", RTLD_LAZY | RTLD_LOCAL);
     if (!g_proxy_resolver_gnome3.gio_module)
@@ -273,16 +268,17 @@ bool proxy_resolver_gnome3_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_gnome3_i = {proxy_resolver_gnome3_get_proxies_for_url,
-                                                         proxy_resolver_gnome3_discover_proxies_for_url,
-                                                         proxy_resolver_gnome3_get_list,
-                                                         proxy_resolver_gnome3_get_error,
-                                                         proxy_resolver_gnome3_wait,
-                                                         proxy_resolver_gnome3_cancel,
-                                                         proxy_resolver_gnome3_create,
-                                                         proxy_resolver_gnome3_delete,
-                                                         proxy_resolver_gnome3_is_discover_async,
-                                                         proxy_resolver_gnome3_global_init,
-                                                         proxy_resolver_gnome3_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_gnome3_i = {
+        proxy_resolver_gnome3_get_proxies_for_url,
+        proxy_resolver_gnome3_discover_proxies_for_url,
+        proxy_resolver_gnome3_get_list,
+        proxy_resolver_gnome3_get_error,
+        proxy_resolver_gnome3_wait,
+        proxy_resolver_gnome3_cancel,
+        proxy_resolver_gnome3_create,
+        proxy_resolver_gnome3_delete,
+        false /* discover_proxies_for_url should be spooled to another thread */,
+        proxy_resolver_gnome3_global_init,
+        proxy_resolver_gnome3_global_cleanup};
     return &proxy_resolver_gnome3_i;
 }

--- a/resolver_gnome3.c
+++ b/resolver_gnome3.c
@@ -117,7 +117,7 @@ static bool proxy_resolver_gnome3_get_proxies(proxy_resolver_gnome3_s *proxy_res
     return true;
 }
 
-bool proxy_resolver_gnome3_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_gnome3_s *proxy_resolver = (proxy_resolver_gnome3_s *)ctx;
     GError *error = NULL;
     char **proxies = NULL;
@@ -262,15 +262,15 @@ bool proxy_resolver_gnome3_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_gnome3_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_gnome3_i = {
-        proxy_resolver_gnome3_discover_proxies_for_url,
+        proxy_resolver_gnome3_get_proxies_for_url,
         proxy_resolver_gnome3_get_list,
         proxy_resolver_gnome3_get_error,
         proxy_resolver_gnome3_wait,
         proxy_resolver_gnome3_cancel,
         proxy_resolver_gnome3_create,
         proxy_resolver_gnome3_delete,
-        false /* discover_proxies_for_url should be spooled to another thread */,
-        true /* discover_proxies_for_url takes into account system config */,
+        false /* get_proxies_for_url should be spooled to another thread */,
+        true /* get_proxies_for_url takes into account system config */,
         proxy_resolver_gnome3_global_init,
         proxy_resolver_gnome3_global_cleanup};
     return &proxy_resolver_gnome3_i;

--- a/resolver_gnome3.h
+++ b/resolver_gnome3.h
@@ -1,6 +1,6 @@
 #pragma once
 
-bool proxy_resolver_gnome3_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_gnome3_get_list(void *ctx);
 int32_t proxy_resolver_gnome3_get_error(void *ctx);
 bool proxy_resolver_gnome3_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_gnome3.h
+++ b/resolver_gnome3.h
@@ -1,6 +1,5 @@
 #pragma once
 
-bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url);
 bool proxy_resolver_gnome3_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_gnome3_get_list(void *ctx);
 int32_t proxy_resolver_gnome3_get_error(void *ctx);

--- a/resolver_gnome3.h
+++ b/resolver_gnome3.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_gnome3_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_gnome3_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_gnome3_get_list(void *ctx);
 int32_t proxy_resolver_gnome3_get_error(void *ctx);
 bool proxy_resolver_gnome3_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_gnome3_cancel(void *ctx);
 void *proxy_resolver_gnome3_create(void);
 bool proxy_resolver_gnome3_delete(void **ctx);
 
-bool proxy_resolver_gnome3_is_async(void);
+bool proxy_resolver_gnome3_is_discover_async(void);
 
 bool proxy_resolver_gnome3_global_init(void);
 bool proxy_resolver_gnome3_global_cleanup(void);

--- a/resolver_gnome3.h
+++ b/resolver_gnome3.h
@@ -10,8 +10,6 @@ bool proxy_resolver_gnome3_cancel(void *ctx);
 void *proxy_resolver_gnome3_create(void);
 bool proxy_resolver_gnome3_delete(void **ctx);
 
-bool proxy_resolver_gnome3_is_discover_async(void);
-
 bool proxy_resolver_gnome3_global_init(void);
 bool proxy_resolver_gnome3_global_cleanup(void);
 

--- a/resolver_i.h
+++ b/resolver_i.h
@@ -2,6 +2,7 @@
 
 typedef struct proxy_resolver_i_s {
     bool (*get_proxies_for_url)(void *ctx, const char *url);
+    bool (*discover_proxies_for_url)(void *ctx, const char *url);
 
     const char *(*get_list)(void *ctx);
     int32_t (*get_error)(void *ctx);
@@ -11,7 +12,7 @@ typedef struct proxy_resolver_i_s {
     void *(*create)(void);
     bool (*delete)(void **ctx);
 
-    bool (*is_async)(void);
+    bool (*is_discover_async)(void);
 
     bool (*global_init)(void);
     bool (*global_cleanup)(void);

--- a/resolver_i.h
+++ b/resolver_i.h
@@ -1,7 +1,7 @@
 #pragma once
 
 typedef struct proxy_resolver_i_s {
-    bool (*discover_proxies_for_url)(void *ctx, const char *url);
+    bool (*get_proxies_for_url)(void *ctx, const char *url);
 
     const char *(*get_list)(void *ctx);
     int32_t (*get_error)(void *ctx);
@@ -11,8 +11,8 @@ typedef struct proxy_resolver_i_s {
     void *(*create)(void);
     bool (*delete)(void **ctx);
 
-    bool discover_is_async;
-    bool discover_uses_system_config;
+    bool is_async;
+    bool uses_system_config;
 
     bool (*global_init)(void);
     bool (*global_cleanup)(void);

--- a/resolver_i.h
+++ b/resolver_i.h
@@ -1,7 +1,6 @@
 #pragma once
 
 typedef struct proxy_resolver_i_s {
-    bool (*get_proxies_for_url)(void *ctx, const char *url);
     bool (*discover_proxies_for_url)(void *ctx, const char *url);
 
     const char *(*get_list)(void *ctx);
@@ -12,7 +11,8 @@ typedef struct proxy_resolver_i_s {
     void *(*create)(void);
     bool (*delete)(void **ctx);
 
-    bool is_discover_async;
+    bool discover_is_async;
+    bool discover_uses_system_config;
 
     bool (*global_init)(void);
     bool (*global_cleanup)(void);

--- a/resolver_i.h
+++ b/resolver_i.h
@@ -12,7 +12,7 @@ typedef struct proxy_resolver_i_s {
     void *(*create)(void);
     bool (*delete)(void **ctx);
 
-    bool (*is_discover_async)(void);
+    bool is_discover_async;
 
     bool (*global_init)(void);
     bool (*global_cleanup)(void);

--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -243,8 +243,8 @@ proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
         proxy_resolver_mac_cancel,
         proxy_resolver_mac_create,
         proxy_resolver_mac_delete,
-        false /* get_proxies_for_url should be spooled to another thread */,
-        false /* get_proxies_for_url does not take into account system config */,
+        false,  // get_proxies_for_url should be spooled to another thread
+        false,  // get_proxies_for_url does not take into account system config
         proxy_resolver_mac_global_init,
         proxy_resolver_mac_global_cleanup};
     return &proxy_resolver_mac_i;

--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -237,11 +237,6 @@ bool proxy_resolver_mac_wait(void *ctx, int32_t timeout_ms) {
     return event_wait(proxy_resolver->complete, timeout_ms);
 }
 
-bool proxy_resolver_mac_is_discover_async(void) {
-    // discover_proxies_for_url should be spooled to another thread
-    return false;
-}
-
 bool proxy_resolver_mac_cancel(void *ctx) {
     return false;
 }
@@ -281,16 +276,17 @@ bool proxy_resolver_mac_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_mac_i = {proxy_resolver_mac_get_proxies_for_url,
-                                                      proxy_resolver_mac_discover_proxies_for_url,
-                                                      proxy_resolver_mac_get_list,
-                                                      proxy_resolver_mac_get_error,
-                                                      proxy_resolver_mac_wait,
-                                                      proxy_resolver_mac_cancel,
-                                                      proxy_resolver_mac_create,
-                                                      proxy_resolver_mac_delete,
-                                                      proxy_resolver_mac_is_discover_async,
-                                                      proxy_resolver_mac_global_init,
-                                                      proxy_resolver_mac_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_mac_i = {
+        proxy_resolver_mac_get_proxies_for_url,
+        proxy_resolver_mac_discover_proxies_for_url,
+        proxy_resolver_mac_get_list,
+        proxy_resolver_mac_get_error,
+        proxy_resolver_mac_wait,
+        proxy_resolver_mac_cancel,
+        proxy_resolver_mac_create,
+        proxy_resolver_mac_delete,
+        false /* discover_proxies_for_url should be spooled to another thread */,
+        proxy_resolver_mac_global_init,
+        proxy_resolver_mac_global_cleanup};
     return &proxy_resolver_mac_i;
 }

--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -111,7 +111,7 @@ static void proxy_resolver_mac_auto_config_result_callback(void *client, CFArray
     return;
 }
 
-bool proxy_resolver_mac_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_mac_s *proxy_resolver = (proxy_resolver_mac_s *)ctx;
     CFURLRef target_url_ref = NULL;
     CFURLRef url_ref = NULL;
@@ -236,15 +236,15 @@ bool proxy_resolver_mac_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_mac_i = {
-        proxy_resolver_mac_discover_proxies_for_url,
+        proxy_resolver_mac_get_proxies_for_url,
         proxy_resolver_mac_get_list,
         proxy_resolver_mac_get_error,
         proxy_resolver_mac_wait,
         proxy_resolver_mac_cancel,
         proxy_resolver_mac_create,
         proxy_resolver_mac_delete,
-        false /* discover_proxies_for_url should be spooled to another thread */,
-        true /* discover_proxies_for_url does not take into account system config */,
+        false /* get_proxies_for_url should be spooled to another thread */,
+        true /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_mac_global_init,
         proxy_resolver_mac_global_cleanup};
     return &proxy_resolver_mac_i;

--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -33,47 +33,6 @@ typedef struct proxy_resolver_mac_s {
     char *list;
 } proxy_resolver_mac_s;
 
-bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url) {
-    proxy_resolver_mac_s *proxy_resolver = (proxy_resolver_mac_s *)ctx;
-    char *auto_config_url = NULL;
-    char *proxy = NULL;
-
-    // Skip if requires auto config url evaluation for proxy resolution
-    auto_config_url = proxy_config_get_auto_config_url();
-    if (auto_config_url)
-        goto mac_done;
-
-    // Check to see if manually configured proxy is specified in system settings
-    proxy = proxy_config_get_proxy(url);
-    if (proxy) {
-        // Check to see if we need to bypass the proxy for the url
-        char *bypass_list = proxy_config_get_bypass_list();
-        bool should_bypass = should_bypass_proxy(url, bypass_list);
-        if (should_bypass) {
-            // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
-            proxy_resolver->list = strdup("direct://");
-        } else {
-            // Use proxy from settings
-            proxy_resolver->list = get_url_from_host(url, proxy);
-        }
-        free(bypass_list);
-    } else {
-        // Use DIRECT connection since no proxy auto-discovery is necessary
-        proxy_resolver->list = strdup("direct://");
-    }
-
-mac_done:
-
-    if (proxy_resolver->list)
-        event_set(proxy_resolver->complete);
-
-    free(proxy);
-    free(auto_config_url);
-
-    return proxy_resolver->list != NULL;
-}
-
 static void proxy_resolver_mac_auto_config_result_callback(void *client, CFArrayRef proxy_array, CFErrorRef error) {
     proxy_resolver_mac_s *proxy_resolver = (proxy_resolver_mac_s *)client;
     if (error) {
@@ -277,7 +236,6 @@ bool proxy_resolver_mac_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_mac_i = {
-        proxy_resolver_mac_get_proxies_for_url,
         proxy_resolver_mac_discover_proxies_for_url,
         proxy_resolver_mac_get_list,
         proxy_resolver_mac_get_error,
@@ -286,6 +244,7 @@ proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
         proxy_resolver_mac_create,
         proxy_resolver_mac_delete,
         false /* discover_proxies_for_url should be spooled to another thread */,
+        true /* discover_proxies_for_url does not take into account system config */,
         proxy_resolver_mac_global_init,
         proxy_resolver_mac_global_cleanup};
     return &proxy_resolver_mac_i;

--- a/resolver_mac.c
+++ b/resolver_mac.c
@@ -244,7 +244,7 @@ proxy_resolver_i_s *proxy_resolver_mac_get_interface(void) {
         proxy_resolver_mac_create,
         proxy_resolver_mac_delete,
         false /* get_proxies_for_url should be spooled to another thread */,
-        true /* get_proxies_for_url does not take into account system config */,
+        false /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_mac_global_init,
         proxy_resolver_mac_global_cleanup};
     return &proxy_resolver_mac_i;

--- a/resolver_mac.h
+++ b/resolver_mac.h
@@ -1,6 +1,5 @@
 #pragma once
 
-bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url);
 bool proxy_resolver_mac_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_mac_get_list(void *ctx);
 int32_t proxy_resolver_mac_get_error(void *ctx);

--- a/resolver_mac.h
+++ b/resolver_mac.h
@@ -10,8 +10,6 @@ bool proxy_resolver_mac_cancel(void *ctx);
 void *proxy_resolver_mac_create(void);
 bool proxy_resolver_mac_delete(void **ctx);
 
-bool proxy_resolver_mac_is_discover_async(void);
-
 bool proxy_resolver_mac_global_init(void);
 bool proxy_resolver_mac_global_cleanup(void);
 

--- a/resolver_mac.h
+++ b/resolver_mac.h
@@ -1,6 +1,6 @@
 #pragma once
 
-bool proxy_resolver_mac_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_mac_get_list(void *ctx);
 int32_t proxy_resolver_mac_get_error(void *ctx);
 bool proxy_resolver_mac_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_mac.h
+++ b/resolver_mac.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_mac_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_mac_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_mac_get_list(void *ctx);
 int32_t proxy_resolver_mac_get_error(void *ctx);
 bool proxy_resolver_mac_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_mac_cancel(void *ctx);
 void *proxy_resolver_mac_create(void);
 bool proxy_resolver_mac_delete(void **ctx);
 
-bool proxy_resolver_mac_is_async(void);
+bool proxy_resolver_mac_is_discover_async(void);
 
 bool proxy_resolver_mac_global_init(void);
 bool proxy_resolver_mac_global_cleanup(void);

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -297,7 +297,7 @@ proxy_resolver_i_s *proxy_resolver_posix_get_interface(void) {
         proxy_resolver_posix_create,
         proxy_resolver_posix_delete,
         false /* get_proxies_for_url should be spooled to another thread */,
-        true /* get_proxies_for_url does not take into account system config */,
+        false /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_posix_global_init,
         proxy_resolver_posix_global_cleanup};
     return &proxy_resolver_posix_i;

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -288,11 +288,6 @@ bool proxy_resolver_posix_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_posix_is_discover_async(void) {
-    // discover_proxies_for_url should be spooled to another thread
-    return false;
-}
-
 static void proxy_resolver_posix_wpad_startup(void *arg) {
     UNUSED(arg);
 
@@ -343,16 +338,17 @@ bool proxy_resolver_posix_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_posix_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_posix_i = {proxy_resolver_posix_get_proxies_for_url,
-                                                        proxy_resolver_posix_discover_proxies_for_url,
-                                                        proxy_resolver_posix_get_list,
-                                                        proxy_resolver_posix_get_error,
-                                                        proxy_resolver_posix_wait,
-                                                        proxy_resolver_posix_cancel,
-                                                        proxy_resolver_posix_create,
-                                                        proxy_resolver_posix_delete,
-                                                        proxy_resolver_posix_is_discover_async,
-                                                        proxy_resolver_posix_global_init,
-                                                        proxy_resolver_posix_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_posix_i = {
+        proxy_resolver_posix_get_proxies_for_url,
+        proxy_resolver_posix_discover_proxies_for_url,
+        proxy_resolver_posix_get_list,
+        proxy_resolver_posix_get_error,
+        proxy_resolver_posix_wait,
+        proxy_resolver_posix_cancel,
+        proxy_resolver_posix_create,
+        proxy_resolver_posix_delete,
+        false /* discover_proxies_for_url should be spooled to another thread */,
+        proxy_resolver_posix_global_init,
+        proxy_resolver_posix_global_cleanup};
     return &proxy_resolver_posix_i;
 }

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -112,7 +112,7 @@ static char *proxy_resolver_posix_fetch_pac(const char *auto_config_url, int32_t
     return script;
 }
 
-bool proxy_resolver_posix_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_posix_s *proxy_resolver = (proxy_resolver_posix_s *)ctx;
     char *auto_config_url = NULL;
     char *proxy = NULL;
@@ -289,15 +289,15 @@ bool proxy_resolver_posix_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_posix_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_posix_i = {
-        proxy_resolver_posix_discover_proxies_for_url,
+        proxy_resolver_posix_get_proxies_for_url,
         proxy_resolver_posix_get_list,
         proxy_resolver_posix_get_error,
         proxy_resolver_posix_wait,
         proxy_resolver_posix_cancel,
         proxy_resolver_posix_create,
         proxy_resolver_posix_delete,
-        false /* discover_proxies_for_url should be spooled to another thread */,
-        true /* discover_proxies_for_url does not take into account system config */,
+        false /* get_proxies_for_url should be spooled to another thread */,
+        true /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_posix_global_init,
         proxy_resolver_posix_global_cleanup};
     return &proxy_resolver_posix_i;

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -47,6 +47,56 @@ typedef struct proxy_resolver_posix_s {
     char *list;
 } proxy_resolver_posix_s;
 
+bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url) {
+    proxy_resolver_posix_s *proxy_resolver = (proxy_resolver_posix_s *)ctx;
+    char *auto_config_url = NULL;
+    char *proxy = NULL;
+    char *scheme = NULL;
+
+    // Skip if requires auto config url evaluation for proxy resolution
+    auto_config_url = proxy_config_get_auto_config_url();
+    if (auto_config_url)
+        goto posix_done;
+
+    // Use scheme associated with the URL when determining proxy
+    scheme = get_url_scheme(url, "http");
+    if (!scheme) {
+        proxy_resolver->error = ENOMEM;
+        LOG_ERROR("Unable to allocate memory for %s (%" PRId32 ")\n", "scheme", proxy_resolver->error);
+        goto posix_done;
+    }
+
+    // Check to see if manually configured proxy is specified in system settings
+    proxy = proxy_config_get_proxy(scheme);
+    if (proxy) {
+        // Check to see if we need to bypass the proxy for the url
+        char *bypass_list = proxy_config_get_bypass_list();
+        bool should_bypass = should_bypass_proxy(url, bypass_list);
+        if (should_bypass) {
+            // Bypass the proxy for the url
+            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
+            proxy_resolver->list = strdup("direct://");
+        } else {
+            // Use proxy from settings
+            proxy_resolver->list = get_url_from_host(url, proxy);
+        }
+        free(bypass_list);
+    } else if (!proxy_config_get_auto_discover()) {
+        // Use DIRECT connection since no proxy auto-discovery is necessary
+        proxy_resolver->list = strdup("direct://");
+    }
+
+posix_done:
+    if (proxy_resolver->list)
+        event_set(proxy_resolver->complete);
+
+    free(scheme);
+    free(proxy);
+    free(auto_config_url);
+
+    return proxy_resolver->list != NULL;
+};
+
 static char *proxy_resolver_posix_wpad_discover(void) {
     char *auto_config_url = NULL;
     char *script = NULL;
@@ -112,23 +162,14 @@ static char *proxy_resolver_posix_fetch_pac(const char *auto_config_url, int32_t
     return script;
 }
 
-bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_posix_discover_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_posix_s *proxy_resolver = (proxy_resolver_posix_s *)ctx;
     char *auto_config_url = NULL;
     char *proxy = NULL;
-    char *bypass_list = NULL;
-    char *scheme = NULL;
     char *script = NULL;
+    char *scheme = NULL;
     bool locked = false;
     bool is_ok = false;
-
-    // Use scheme associated with the URL when determining proxy
-    scheme = get_url_scheme(url, "http");
-    if (!scheme) {
-        proxy_resolver->error = ENOMEM;
-        LOG_ERROR("Unable to allocate memory for %s (%" PRId32 ")\n", "scheme", proxy_resolver->error);
-        goto posix_done;
-    }
 
     if (proxy_config_get_auto_discover()) {
         locked = mutex_lock(g_proxy_resolver_posix.mutex);
@@ -165,32 +206,23 @@ bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url) {
         // Get return value from FindProxyForURL
         const char *list = proxy_execute_get_list(proxy_execute);
 
+        // Use scheme associated with the URL when determining proxy
+        scheme = get_url_scheme(url, "http");
+        if (!scheme) {
+            proxy_resolver->error = ENOMEM;
+            LOG_ERROR("Unable to allocate memory for %s (%" PRId32 ")\n", "scheme", proxy_resolver->error);
+            goto posix_done;
+        }
+
         // Convert return value from FindProxyForURL to uri list. We use the default
         // scheme corresponding to the protocol of the original request.
         proxy_resolver->list = convert_proxy_list_to_uri_list(list, scheme);
 
         proxy_execute_delete(&proxy_execute);
-        goto posix_done;
+    } else {
+        // Use DIRECT connection since WPAD didn't result in a proxy auto-configuration url
+        proxy_resolver->list = strdup("direct://");
     }
-
-    if ((proxy = proxy_config_get_proxy(scheme)) != NULL) {
-        // Check to see if we need to bypass the proxy for the url
-        bool should_bypass = false;
-        bypass_list = proxy_config_get_bypass_list();
-        should_bypass = should_bypass_proxy(url, bypass_list);
-        if (should_bypass) {
-            // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
-            proxy_resolver->list = strdup("direct://");
-        } else {
-            // Use proxy from settings
-            proxy_resolver->list = get_url_from_host(scheme, proxy);
-        }
-        goto posix_done;
-    }
-
-    // Use DIRECT connection
-    proxy_resolver->list = strdup("direct://");
 
 posix_done:
 
@@ -201,8 +233,6 @@ posix_done:
     event_set(proxy_resolver->complete);
 
     free(scheme);
-
-    free(bypass_list);
     free(proxy);
     free(auto_config_url);
 
@@ -258,7 +288,8 @@ bool proxy_resolver_posix_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_posix_is_async(void) {
+bool proxy_resolver_posix_is_discover_async(void) {
+    // discover_proxies_for_url should be spooled to another thread
     return false;
 }
 
@@ -313,13 +344,14 @@ bool proxy_resolver_posix_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_posix_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_posix_i = {proxy_resolver_posix_get_proxies_for_url,
+                                                        proxy_resolver_posix_discover_proxies_for_url,
                                                         proxy_resolver_posix_get_list,
                                                         proxy_resolver_posix_get_error,
                                                         proxy_resolver_posix_wait,
                                                         proxy_resolver_posix_cancel,
                                                         proxy_resolver_posix_create,
                                                         proxy_resolver_posix_delete,
-                                                        proxy_resolver_posix_is_async,
+                                                        proxy_resolver_posix_is_discover_async,
                                                         proxy_resolver_posix_global_init,
                                                         proxy_resolver_posix_global_cleanup};
     return &proxy_resolver_posix_i;

--- a/resolver_posix.c
+++ b/resolver_posix.c
@@ -296,8 +296,8 @@ proxy_resolver_i_s *proxy_resolver_posix_get_interface(void) {
         proxy_resolver_posix_cancel,
         proxy_resolver_posix_create,
         proxy_resolver_posix_delete,
-        false /* get_proxies_for_url should be spooled to another thread */,
-        false /* get_proxies_for_url does not take into account system config */,
+        false,  // get_proxies_for_url should be spooled to another thread
+        false,  // get_proxies_for_url does not take into account system config
         proxy_resolver_posix_global_init,
         proxy_resolver_posix_global_cleanup};
     return &proxy_resolver_posix_i;

--- a/resolver_posix.h
+++ b/resolver_posix.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_posix_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_posix_get_list(void *ctx);
 int32_t proxy_resolver_posix_get_error(void *ctx);
 bool proxy_resolver_posix_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_posix_cancel(void *ctx);
 void *proxy_resolver_posix_create(void);
 bool proxy_resolver_posix_delete(void **ctx);
 
-bool proxy_resolver_posix_is_async(void);
+bool proxy_resolver_posix_is_discover_async(void);
 
 bool proxy_resolver_posix_global_init(void);
 bool proxy_resolver_posix_init_ex(void *threadpool);

--- a/resolver_posix.h
+++ b/resolver_posix.h
@@ -10,8 +10,6 @@ bool proxy_resolver_posix_cancel(void *ctx);
 void *proxy_resolver_posix_create(void);
 bool proxy_resolver_posix_delete(void **ctx);
 
-bool proxy_resolver_posix_is_discover_async(void);
-
 bool proxy_resolver_posix_global_init(void);
 bool proxy_resolver_posix_init_ex(void *threadpool);
 bool proxy_resolver_posix_global_cleanup(void);

--- a/resolver_posix.h
+++ b/resolver_posix.h
@@ -1,7 +1,7 @@
 #pragma once
 
 bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url);
-bool proxy_resolver_posix_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_posix_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_posix_get_list(void *ctx);
 int32_t proxy_resolver_posix_get_error(void *ctx);
 bool proxy_resolver_posix_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -169,7 +169,7 @@ bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url) {
 
     auto_config_url = proxy_config_get_auto_config_url();
     if (auto_config_url) {
-        // Use auto configuration script specified in system settings
+        // Use auto configuration script specified by system
         auto_config_url_wide = utf8_dup_to_wchar(auto_config_url);
         if (!auto_config_url_wide) {
             proxy_resolver->error = ERROR_OUTOFMEMORY;

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -356,11 +356,6 @@ bool proxy_resolver_win8_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_win8_is_discover_async(void) {
-    // discover_proxies_for_url is handled asynchronous
-    return true;
-}
-
 bool proxy_resolver_win8_global_init(void) {
     // Dynamically load WinHTTP and CreateProxyResolver which is only avaialble on Windows 8 or higher
     g_proxy_resolver_win8.win_http = LoadLibraryExA("winhttp.dll", NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
@@ -419,7 +414,7 @@ proxy_resolver_i_s *proxy_resolver_win8_get_interface(void) {
                                                        proxy_resolver_win8_cancel,
                                                        proxy_resolver_win8_create,
                                                        proxy_resolver_win8_delete,
-                                                       proxy_resolver_win8_is_discover_async,
+                                                       true /* discover_proxies_for_url is handled asynchronous */,
                                                        proxy_resolver_win8_global_init,
                                                        proxy_resolver_win8_global_cleanup};
     return &proxy_resolver_win8_i;

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -364,8 +364,8 @@ proxy_resolver_i_s *proxy_resolver_win8_get_interface(void) {
         proxy_resolver_win8_cancel,
         proxy_resolver_win8_create,
         proxy_resolver_win8_delete,
-        true /* get_proxies_for_url is handled asynchronously */,
-        false /* get_proxies_for_url does not take into account system config */,
+        true,   // get_proxies_for_url is handled asynchronously
+        false,  // get_proxies_for_url does not take into account system config
         proxy_resolver_win8_global_init,
         proxy_resolver_win8_global_cleanup};
     return &proxy_resolver_win8_i;

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -48,56 +48,6 @@ typedef struct proxy_resolver_win8_s {
     char *list;
 } proxy_resolver_win8_s;
 
-bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url) {
-    proxy_resolver_win8_s *proxy_resolver = (proxy_resolver_win8_s *)ctx;
-    char *auto_config_url = NULL;
-    char *proxy = NULL;
-    char *scheme = NULL;
-
-    // Skip if requires auto config url evaluation for proxy resolution
-    auto_config_url = proxy_config_get_auto_config_url();
-    if (auto_config_url)
-        goto win8_done;
-
-    // Use scheme associated with the URL when determining proxy
-    scheme = get_url_scheme(url, "http");
-    if (!scheme) {
-        proxy_resolver->error = ERROR_OUTOFMEMORY;
-        LOG_ERROR("Unable to allocate memory for %s (%" PRId32 ")\n", "scheme", proxy_resolver->error);
-        goto win8_done;
-    }
-
-    // Check to see if manually configured proxy is specified in system settings
-    proxy = proxy_config_get_proxy(scheme);
-    if (proxy) {
-        // Check to see if we need to bypass the proxy for the url
-        char *bypass_list = proxy_config_get_bypass_list();
-        bool should_bypass = should_bypass_proxy(url, bypass_list);
-        if (should_bypass) {
-            // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
-            proxy_resolver->list = strdup("direct://");
-        } else {
-            // Use proxy from settings
-            proxy_resolver->list = get_url_from_host(url, proxy);
-        }
-        free(bypass_list);
-    } else if (!proxy_config_get_auto_discover()) {
-        // Use DIRECT connection since no proxy auto-discovery is necessary
-        proxy_resolver->list = strdup("direct://");
-    }
-
-win8_done:
-    if (proxy_resolver->list)
-        event_set(proxy_resolver->complete);
-
-    free(scheme);
-    free(proxy);
-    free(auto_config_url);
-
-    return proxy_resolver->list != NULL;
-}
-
 void CALLBACK proxy_resolver_win8_winhttp_status_callback(HINTERNET Internet, DWORD_PTR Context, DWORD InternetStatus,
                                                           LPVOID StatusInformation, DWORD StatusInformationLength) {
     proxy_resolver_win8_s *proxy_resolver = (proxy_resolver_win8_s *)Context;
@@ -406,16 +356,17 @@ bool proxy_resolver_win8_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_win8_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_win8_i = {proxy_resolver_win8_get_proxies_for_url,
-                                                       proxy_resolver_win8_discover_proxies_for_url,
-                                                       proxy_resolver_win8_get_list,
-                                                       proxy_resolver_win8_get_error,
-                                                       proxy_resolver_win8_wait,
-                                                       proxy_resolver_win8_cancel,
-                                                       proxy_resolver_win8_create,
-                                                       proxy_resolver_win8_delete,
-                                                       true /* discover_proxies_for_url is handled asynchronous */,
-                                                       proxy_resolver_win8_global_init,
-                                                       proxy_resolver_win8_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_win8_i = {
+        proxy_resolver_win8_discover_proxies_for_url,
+        proxy_resolver_win8_get_list,
+        proxy_resolver_win8_get_error,
+        proxy_resolver_win8_wait,
+        proxy_resolver_win8_cancel,
+        proxy_resolver_win8_create,
+        proxy_resolver_win8_delete,
+        true /* discover_proxies_for_url is handled asynchronously */,
+        false /* discover_proxies_for_url does not take into account system config */,
+        proxy_resolver_win8_global_init,
+        proxy_resolver_win8_global_cleanup};
     return &proxy_resolver_win8_i;
 }

--- a/resolver_win8.c
+++ b/resolver_win8.c
@@ -157,7 +157,7 @@ win8_async_done:
     event_set(proxy_resolver->complete);
 }
 
-bool proxy_resolver_win8_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_win8_s *proxy_resolver = (proxy_resolver_win8_s *)ctx;
     WINHTTP_AUTOPROXY_OPTIONS options = {0};
     WINHTTP_PROXY_INFO proxy_info = {0};
@@ -357,15 +357,15 @@ bool proxy_resolver_win8_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_win8_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_win8_i = {
-        proxy_resolver_win8_discover_proxies_for_url,
+        proxy_resolver_win8_get_proxies_for_url,
         proxy_resolver_win8_get_list,
         proxy_resolver_win8_get_error,
         proxy_resolver_win8_wait,
         proxy_resolver_win8_cancel,
         proxy_resolver_win8_create,
         proxy_resolver_win8_delete,
-        true /* discover_proxies_for_url is handled asynchronously */,
-        false /* discover_proxies_for_url does not take into account system config */,
+        true /* get_proxies_for_url is handled asynchronously */,
+        false /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_win8_global_init,
         proxy_resolver_win8_global_cleanup};
     return &proxy_resolver_win8_i;

--- a/resolver_win8.h
+++ b/resolver_win8.h
@@ -1,6 +1,6 @@
 #pragma once
 
-bool proxy_resolver_win8_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_win8_get_list(void *ctx);
 int32_t proxy_resolver_win8_get_error(void *ctx);
 bool proxy_resolver_win8_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_win8.h
+++ b/resolver_win8.h
@@ -10,8 +10,6 @@ bool proxy_resolver_win8_cancel(void *ctx);
 void *proxy_resolver_win8_create(void);
 bool proxy_resolver_win8_delete(void **ctx);
 
-bool proxy_resolver_win8_is_discover_async(void);
-
 bool proxy_resolver_win8_global_init(void);
 bool proxy_resolver_win8_global_cleanup(void);
 

--- a/resolver_win8.h
+++ b/resolver_win8.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_win8_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_win8_get_list(void *ctx);
 int32_t proxy_resolver_win8_get_error(void *ctx);
 bool proxy_resolver_win8_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_win8_cancel(void *ctx);
 void *proxy_resolver_win8_create(void);
 bool proxy_resolver_win8_delete(void **ctx);
 
-bool proxy_resolver_win8_is_async(void);
+bool proxy_resolver_win8_is_discover_async(void);
 
 bool proxy_resolver_win8_global_init(void);
 bool proxy_resolver_win8_global_cleanup(void);

--- a/resolver_win8.h
+++ b/resolver_win8.h
@@ -1,6 +1,5 @@
 #pragma once
 
-bool proxy_resolver_win8_get_proxies_for_url(void *ctx, const char *url);
 bool proxy_resolver_win8_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_win8_get_list(void *ctx);
 int32_t proxy_resolver_win8_get_error(void *ctx);

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -276,13 +276,6 @@ static WinRT_IUriRuntimeClass *create_uri_from_string(const char *url) {
     return uri;
 }
 
-bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url) {
-    UNUSED(ctx);
-    UNUSED(url);
-    // All proxy resolution must go through ProxyConfiguration async operation
-    return false;
-}
-
 bool proxy_resolver_winrt_discover_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_winrt_s *proxy_resolver = (proxy_resolver_winrt_s *)ctx;
     WinRT_INetworkInformationStatics *network_info_statics = NULL;
@@ -404,16 +397,17 @@ bool proxy_resolver_winrt_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_winrt_i = {proxy_resolver_winrt_get_proxies_for_url,
-                                                        proxy_resolver_winrt_discover_proxies_for_url,
-                                                        proxy_resolver_winrt_get_list,
-                                                        proxy_resolver_winrt_get_error,
-                                                        proxy_resolver_winrt_wait,
-                                                        proxy_resolver_winrt_cancel,
-                                                        proxy_resolver_winrt_create,
-                                                        proxy_resolver_winrt_delete,
-                                                        true /* discover_proxies_for_url is handled asynchronous */,
-                                                        proxy_resolver_winrt_global_init,
-                                                        proxy_resolver_winrt_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_winrt_i = {
+        proxy_resolver_winrt_discover_proxies_for_url,
+        proxy_resolver_winrt_get_list,
+        proxy_resolver_winrt_get_error,
+        proxy_resolver_winrt_wait,
+        proxy_resolver_winrt_cancel,
+        proxy_resolver_winrt_create,
+        proxy_resolver_winrt_delete,
+        true /* discover_proxies_for_url is handled asynchronously */,
+        true /* discover_proxies_for_url takes into account system config */,
+        proxy_resolver_winrt_global_init,
+        proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;
 }

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -397,17 +397,16 @@ bool proxy_resolver_winrt_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_winrt_i = {
-        proxy_resolver_winrt_get_proxies_for_url,
-        proxy_resolver_winrt_get_list,
-        proxy_resolver_winrt_get_error,
-        proxy_resolver_winrt_wait,
-        proxy_resolver_winrt_cancel,
-        proxy_resolver_winrt_create,
-        proxy_resolver_winrt_delete,
-        true /* get_proxies_for_url is handled asynchronously */,
-        true /* get_proxies_for_url takes into account system config */,
-        proxy_resolver_winrt_global_init,
-        proxy_resolver_winrt_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_winrt_i = {proxy_resolver_winrt_get_proxies_for_url,
+                                                        proxy_resolver_winrt_get_list,
+                                                        proxy_resolver_winrt_get_error,
+                                                        proxy_resolver_winrt_wait,
+                                                        proxy_resolver_winrt_cancel,
+                                                        proxy_resolver_winrt_create,
+                                                        proxy_resolver_winrt_delete,
+                                                        true /* get_proxies_for_url is handled asynchronously */,
+                                                        true /* get_proxies_for_url takes into account system config */,
+                                                        proxy_resolver_winrt_global_init,
+                                                        proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;
 }

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -404,8 +404,8 @@ proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
                                                         proxy_resolver_winrt_cancel,
                                                         proxy_resolver_winrt_create,
                                                         proxy_resolver_winrt_delete,
-                                                        true /* get_proxies_for_url is handled asynchronously */,
-                                                        true /* get_proxies_for_url takes into account system config */,
+                                                        true,  // get_proxies_for_url is handled asynchronously
+                                                        true,  // get_proxies_for_url takes into account system config
                                                         proxy_resolver_winrt_global_init,
                                                         proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -395,11 +395,6 @@ bool proxy_resolver_winrt_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_winrt_is_discover_async(void) {
-    // discover_proxies_for_url is handled asynchronous
-    return true;
-}
-
 bool proxy_resolver_winrt_global_init(void) {
     return true;
 }
@@ -417,7 +412,7 @@ proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
                                                         proxy_resolver_winrt_cancel,
                                                         proxy_resolver_winrt_create,
                                                         proxy_resolver_winrt_delete,
-                                                        proxy_resolver_winrt_is_discover_async,
+                                                        true /* discover_proxies_for_url is handled asynchronous */,
                                                         proxy_resolver_winrt_global_init,
                                                         proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -130,7 +130,6 @@ async_complete_handler_release(WinRT_IAsyncOperationCompletedHandler_ProxyConfig
 
 HRESULT STDMETHODCALLTYPE async_complete_handler_query_interface(
     WinRT_IAsyncOperationCompletedHandler_ProxyConfiguration *handler, REFIID riid, void **ppv) {
-
     if (IsEqualGUID(riid, CIID(IID_AsyncOperationCompletedHandler_ProxyConfiguration)) ||
         IsEqualGUID(riid, CIID(IID_IAgileObject)) || IsEqualGUID(riid, CIID(IID_IUnknown))) {
         async_complete_handler_add_ref(handler);
@@ -278,6 +277,13 @@ static WinRT_IUriRuntimeClass *create_uri_from_string(const char *url) {
 }
 
 bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url) {
+    UNUSED(ctx);
+    UNUSED(url);
+    // All proxy resolution must go through ProxyConfiguration async operation
+    return false;
+}
+
+bool proxy_resolver_winrt_discover_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_winrt_s *proxy_resolver = (proxy_resolver_winrt_s *)ctx;
     WinRT_INetworkInformationStatics *network_info_statics = NULL;
     WinRT_IUriRuntimeClass *uri = NULL;
@@ -307,7 +313,7 @@ bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url) {
         proxy_resolver->complete_handler->ref_count = 1;
         proxy_resolver->complete_handler->proxy_resolver = proxy_resolver;
 
-        // Create proxy configu
+        // Create proxy configuration async operation
         result = WinRT_INetworkInformationStatics_GetProxyConfigurationAsync(network_info_statics, uri,
                                                                              &proxy_resolver->complete_handler->async);
         if (SUCCEEDED(result)) {
@@ -389,7 +395,8 @@ bool proxy_resolver_winrt_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_winrt_is_async(void) {
+bool proxy_resolver_winrt_is_discover_async(void) {
+    // discover_proxies_for_url is handled asynchronous
     return true;
 }
 
@@ -403,13 +410,14 @@ bool proxy_resolver_winrt_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_winrt_i = {proxy_resolver_winrt_get_proxies_for_url,
+                                                        proxy_resolver_winrt_discover_proxies_for_url,
                                                         proxy_resolver_winrt_get_list,
                                                         proxy_resolver_winrt_get_error,
                                                         proxy_resolver_winrt_wait,
                                                         proxy_resolver_winrt_cancel,
                                                         proxy_resolver_winrt_create,
                                                         proxy_resolver_winrt_delete,
-                                                        proxy_resolver_winrt_is_async,
+                                                        proxy_resolver_winrt_is_discover_async,
                                                         proxy_resolver_winrt_global_init,
                                                         proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;

--- a/resolver_winrt.c
+++ b/resolver_winrt.c
@@ -276,7 +276,7 @@ static WinRT_IUriRuntimeClass *create_uri_from_string(const char *url) {
     return uri;
 }
 
-bool proxy_resolver_winrt_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_winrt_s *proxy_resolver = (proxy_resolver_winrt_s *)ctx;
     WinRT_INetworkInformationStatics *network_info_statics = NULL;
     WinRT_IUriRuntimeClass *uri = NULL;
@@ -398,15 +398,15 @@ bool proxy_resolver_winrt_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_winrt_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_winrt_i = {
-        proxy_resolver_winrt_discover_proxies_for_url,
+        proxy_resolver_winrt_get_proxies_for_url,
         proxy_resolver_winrt_get_list,
         proxy_resolver_winrt_get_error,
         proxy_resolver_winrt_wait,
         proxy_resolver_winrt_cancel,
         proxy_resolver_winrt_create,
         proxy_resolver_winrt_delete,
-        true /* discover_proxies_for_url is handled asynchronously */,
-        true /* discover_proxies_for_url takes into account system config */,
+        true /* get_proxies_for_url is handled asynchronously */,
+        true /* get_proxies_for_url takes into account system config */,
         proxy_resolver_winrt_global_init,
         proxy_resolver_winrt_global_cleanup};
     return &proxy_resolver_winrt_i;

--- a/resolver_winrt.h
+++ b/resolver_winrt.h
@@ -1,7 +1,7 @@
 #pragma once
 
 bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url);
-bool proxy_resolver_winrt_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_winrt_get_list(void *ctx);
 int32_t proxy_resolver_winrt_get_error(void *ctx);
 bool proxy_resolver_winrt_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_winrt.h
+++ b/resolver_winrt.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_winrt_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_winrt_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_winrt_get_list(void *ctx);
 int32_t proxy_resolver_winrt_get_error(void *ctx);
 bool proxy_resolver_winrt_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_winrt_cancel(void *ctx);
 void *proxy_resolver_winrt_create(void);
 bool proxy_resolver_winrt_delete(void **ctx);
 
-bool proxy_resolver_winrt_is_async(void);
+bool proxy_resolver_winrt_is_discover_async(void);
 
 bool proxy_resolver_winrt_global_init(void);
 bool proxy_resolver_winrt_global_cleanup(void);

--- a/resolver_winrt.h
+++ b/resolver_winrt.h
@@ -10,8 +10,6 @@ bool proxy_resolver_winrt_cancel(void *ctx);
 void *proxy_resolver_winrt_create(void);
 bool proxy_resolver_winrt_delete(void **ctx);
 
-bool proxy_resolver_winrt_is_discover_async(void);
-
 bool proxy_resolver_winrt_global_init(void);
 bool proxy_resolver_winrt_global_cleanup(void);
 

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -36,7 +36,7 @@ typedef struct proxy_resolver_winxp_s {
     char *list;
 } proxy_resolver_winxp_s;
 
-bool proxy_resolver_winxp_discover_proxies_for_url(void *ctx, const char *url) {
+bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_winxp_s *proxy_resolver = (proxy_resolver_winxp_s *)ctx;
     WINHTTP_AUTOPROXY_OPTIONS options = {0};
     WINHTTP_PROXY_INFO proxy_info = {0};
@@ -227,15 +227,15 @@ bool proxy_resolver_winxp_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_winxp_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_winxp_i = {
-        proxy_resolver_winxp_discover_proxies_for_url,
+        proxy_resolver_winxp_get_proxies_for_url,
         proxy_resolver_winxp_get_list,
         proxy_resolver_winxp_get_error,
         proxy_resolver_winxp_wait,
         proxy_resolver_winxp_cancel,
         proxy_resolver_winxp_create,
         proxy_resolver_winxp_delete,
-        false /* discover_proxies_for_url should be spooled to another thread */,
-        false /* discover_proxies_for_url does not take into account system config */,
+        false /* get_proxies_for_url should be spooled to another thread */,
+        false /* get_proxies_for_url does not take into account system config */,
         proxy_resolver_winxp_global_init,
         proxy_resolver_winxp_global_cleanup};
     return &proxy_resolver_winxp_i;

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -258,11 +258,6 @@ bool proxy_resolver_winxp_delete(void **ctx) {
     return true;
 }
 
-bool proxy_resolver_winxp_is_discover_async(void) {
-    // discover_proxies_for_url should be spooled to another thread
-    return false;
-}
-
 bool proxy_resolver_winxp_global_init(void) {
     g_proxy_resolver_winxp.session =
         WinHttpOpen(L"cproxyres", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
@@ -281,16 +276,17 @@ bool proxy_resolver_winxp_global_cleanup(void) {
 }
 
 proxy_resolver_i_s *proxy_resolver_winxp_get_interface(void) {
-    static proxy_resolver_i_s proxy_resolver_winxp_i = {proxy_resolver_winxp_get_proxies_for_url,
-                                                        proxy_resolver_winxp_discover_proxies_for_url,
-                                                        proxy_resolver_winxp_get_list,
-                                                        proxy_resolver_winxp_get_error,
-                                                        proxy_resolver_winxp_wait,
-                                                        proxy_resolver_winxp_cancel,
-                                                        proxy_resolver_winxp_create,
-                                                        proxy_resolver_winxp_delete,
-                                                        proxy_resolver_winxp_is_discover_async,
-                                                        proxy_resolver_winxp_global_init,
-                                                        proxy_resolver_winxp_global_cleanup};
+    static proxy_resolver_i_s proxy_resolver_winxp_i = {
+        proxy_resolver_winxp_get_proxies_for_url,
+        proxy_resolver_winxp_discover_proxies_for_url,
+        proxy_resolver_winxp_get_list,
+        proxy_resolver_winxp_get_error,
+        proxy_resolver_winxp_wait,
+        proxy_resolver_winxp_cancel,
+        proxy_resolver_winxp_create,
+        proxy_resolver_winxp_delete,
+        false /* discover_proxies_for_url should be spooled to another thread */,
+        proxy_resolver_winxp_global_init,
+        proxy_resolver_winxp_global_cleanup};
     return &proxy_resolver_winxp_i;
 }

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -49,7 +49,7 @@ bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
 
     auto_config_url = proxy_config_get_auto_config_url();
     if (auto_config_url) {
-        // Use auto configuration script specified in system settings
+        // Use auto configuration script specified by system
         auto_config_url_wide = utf8_dup_to_wchar(auto_config_url);
         if (!auto_config_url_wide) {
             proxy_resolver->error = ERROR_OUTOFMEMORY;

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -36,56 +36,6 @@ typedef struct proxy_resolver_winxp_s {
     char *list;
 } proxy_resolver_winxp_s;
 
-bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
-    proxy_resolver_winxp_s *proxy_resolver = (proxy_resolver_winxp_s *)ctx;
-    char *auto_config_url = NULL;
-    char *proxy = NULL;
-    char *scheme = NULL;
-
-    // Skip if requires auto config url evaluation for proxy resolution
-    auto_config_url = proxy_config_get_auto_config_url();
-    if (auto_config_url)
-        goto winxp_done;
-
-    // Use scheme associated with the URL when determining proxy
-    scheme = get_url_scheme(url, "http");
-    if (!scheme) {
-        proxy_resolver->error = ERROR_OUTOFMEMORY;
-        LOG_ERROR("Unable to allocate memory for %s (%" PRId32 ")\n", "scheme", proxy_resolver->error);
-        goto winxp_done;
-    }
-
-    // Check to see if manually configured proxy is specified in system settings
-    proxy = proxy_config_get_proxy(scheme);
-    if (proxy) {
-        // Check to see if we need to bypass the proxy for the url
-        char *bypass_list = proxy_config_get_bypass_list();
-        bool should_bypass = should_bypass_proxy(url, bypass_list);
-        if (should_bypass) {
-            // Bypass the proxy for the url
-            LOG_INFO("Bypassing proxy for %s (%s)\n", url, bypass_list ? bypass_list : "null");
-            proxy_resolver->list = strdup("direct://");
-        } else {
-            // Use proxy from settings
-            proxy_resolver->list = get_url_from_host(url, proxy);
-        }
-        free(bypass_list);
-    } else if (!proxy_config_get_auto_discover()) {
-        // Use DIRECT connection since no proxy auto-discovery is necessary
-        proxy_resolver->list = strdup("direct://");
-    }
-
-winxp_done:
-    if (proxy_resolver->list)
-        event_set(proxy_resolver->complete);
-
-    free(scheme);
-    free(proxy);
-    free(auto_config_url);
-
-    return proxy_resolver->list != NULL;
-}
-
 bool proxy_resolver_winxp_discover_proxies_for_url(void *ctx, const char *url) {
     proxy_resolver_winxp_s *proxy_resolver = (proxy_resolver_winxp_s *)ctx;
     WINHTTP_AUTOPROXY_OPTIONS options = {0};
@@ -277,7 +227,6 @@ bool proxy_resolver_winxp_global_cleanup(void) {
 
 proxy_resolver_i_s *proxy_resolver_winxp_get_interface(void) {
     static proxy_resolver_i_s proxy_resolver_winxp_i = {
-        proxy_resolver_winxp_get_proxies_for_url,
         proxy_resolver_winxp_discover_proxies_for_url,
         proxy_resolver_winxp_get_list,
         proxy_resolver_winxp_get_error,
@@ -286,6 +235,7 @@ proxy_resolver_i_s *proxy_resolver_winxp_get_interface(void) {
         proxy_resolver_winxp_create,
         proxy_resolver_winxp_delete,
         false /* discover_proxies_for_url should be spooled to another thread */,
+        false /* discover_proxies_for_url does not take into account system config */,
         proxy_resolver_winxp_global_init,
         proxy_resolver_winxp_global_cleanup};
     return &proxy_resolver_winxp_i;

--- a/resolver_winxp.c
+++ b/resolver_winxp.c
@@ -113,7 +113,7 @@ bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url) {
         if (proxy_info.lpszProxyBypass)
             bypass_list = wchar_dup_to_utf8(proxy_info.lpszProxyBypass);
         if (bypass_list) {
-            // Check to see if we need to bypass the proxy for the url
+            // Check if we need to bypass the proxy for the url
             bool should_bypass = should_bypass_proxy(url, bypass_list);
             if (should_bypass) {
                 // Bypass the proxy for the url
@@ -234,8 +234,8 @@ proxy_resolver_i_s *proxy_resolver_winxp_get_interface(void) {
         proxy_resolver_winxp_cancel,
         proxy_resolver_winxp_create,
         proxy_resolver_winxp_delete,
-        false /* get_proxies_for_url should be spooled to another thread */,
-        false /* get_proxies_for_url does not take into account system config */,
+        false,  // get_proxies_for_url should be spooled to another thread
+        false,  // get_proxies_for_url does not take into account system config
         proxy_resolver_winxp_global_init,
         proxy_resolver_winxp_global_cleanup};
     return &proxy_resolver_winxp_i;

--- a/resolver_winxp.h
+++ b/resolver_winxp.h
@@ -1,6 +1,6 @@
 #pragma once
 
-bool proxy_resolver_winxp_discover_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_winxp_get_list(void *ctx);
 int32_t proxy_resolver_winxp_get_error(void *ctx);
 bool proxy_resolver_winxp_wait(void *ctx, int32_t timeout_ms);

--- a/resolver_winxp.h
+++ b/resolver_winxp.h
@@ -1,6 +1,7 @@
 #pragma once
 
 bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url);
+bool proxy_resolver_winxp_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_winxp_get_list(void *ctx);
 int32_t proxy_resolver_winxp_get_error(void *ctx);
 bool proxy_resolver_winxp_wait(void *ctx, int32_t timeout_ms);
@@ -9,7 +10,7 @@ bool proxy_resolver_winxp_cancel(void *ctx);
 void *proxy_resolver_winxp_create(void);
 bool proxy_resolver_winxp_delete(void **ctx);
 
-bool proxy_resolver_winxp_is_async(void);
+bool proxy_resolver_winxp_is_discover_async(void);
 
 bool proxy_resolver_winxp_global_init(void);
 bool proxy_resolver_winxp_global_cleanup(void);

--- a/resolver_winxp.h
+++ b/resolver_winxp.h
@@ -10,8 +10,6 @@ bool proxy_resolver_winxp_cancel(void *ctx);
 void *proxy_resolver_winxp_create(void);
 bool proxy_resolver_winxp_delete(void **ctx);
 
-bool proxy_resolver_winxp_is_discover_async(void);
-
 bool proxy_resolver_winxp_global_init(void);
 bool proxy_resolver_winxp_global_cleanup(void);
 

--- a/resolver_winxp.h
+++ b/resolver_winxp.h
@@ -1,6 +1,5 @@
 #pragma once
 
-bool proxy_resolver_winxp_get_proxies_for_url(void *ctx, const char *url);
 bool proxy_resolver_winxp_discover_proxies_for_url(void *ctx, const char *url);
 const char *proxy_resolver_winxp_get_list(void *ctx);
 int32_t proxy_resolver_winxp_get_error(void *ctx);

--- a/util_linux.c
+++ b/util_linux.c
@@ -87,7 +87,7 @@ char *get_config_value(const char *config, const char *section, const char *key)
             }
         }
 
-        // Check to see if we are in the right section
+        // Check if we are in the right section
         if (line_len > 2 && line_start[0] == '[' && line_end[-1] == ']')
             in_section = strncmp(line_start + 1, section, line_len - 2) == 0;
 

--- a/util_win.c
+++ b/util_win.c
@@ -77,7 +77,7 @@ char *get_winhttp_proxy_by_scheme(const char *scheme, const char *proxy_list) {
                 host_start++;
         }
 
-        // Check to see if the scheme in the proxy config matches the url scheme
+        // Check if the scheme in the proxy config matches the url scheme
         if (real_scheme_len == config_scheme_len && _strnicmp(real_scheme, config_scheme, config_scheme_len) == 0) {
             if (!config_end)
                 config_end = host_start + strlen(host_start);


### PR DESCRIPTION
This should allow proxy determination to be quicker when no proxy settings are configured on the machine.