### PR TITLE
Fixed net_adapter_enum not enumerating all adapters on Windows.

### DIFF
--- a/net_adapter_winxp.c
+++ b/net_adapter_winxp.c
@@ -122,7 +122,7 @@ bool net_adapter_enum(void *user_data, net_adapter_cb callback) {
             break;
         }
 
-        if (callback(user_data, &adapter))
+        if (!callback(user_data, &adapter))
             break;
     }
 


### PR DESCRIPTION
Other interfaces have the correct logic.