### PR TITLE
jsc: do not unload the library, as a thread in its address space may run

### DIFF
--- a/execute_jsc.c
+++ b/execute_jsc.c
@@ -336,11 +336,13 @@ bool proxy_execute_jsc_global_init(void) {
 }
 
 bool proxy_execute_jsc_global_cleanup(void) {
+#if 0  // Do not unload the library, as a thread in its address space may run
     if (g_proxy_execute_jsc.module)
         dlclose(g_proxy_execute_jsc.module);
 
     memset(&g_proxy_execute_jsc, 0, sizeof(g_proxy_execute_jsc));
     g_proxy_execute_jsc_init_flag = PTHREAD_ONCE_INIT;
+#endif
     return true;
 }
 


### PR DESCRIPTION
A client app can call `proxyres_global_cleanup()`, continue to run and crash in an unspecified thread, spawned by JSCoreGTK, running in the address space of the unloaded library.

The forced call to the garbage collector does not fix crashes.

Before dlclose():
```
* thread #18, name = 'gtest_host'
  * frame #0: 0x00007ffff2e98d71 libc.so.6`__GI___futex_abstimed_wait_cancelable64 [inlined] __futex_abstimed_wait_common64(private=<unavailable>, cancel=true, abstime=0x00007fff991e8730, op=393, expected=0, futex_word=0x00007fff6c00e810) at futex-internal.c:57:12
    frame #1: 0x00007ffff2e98d47 libc.so.6`__GI___futex_abstimed_wait_cancelable64 [inlined] __futex_abstimed_wait_common(cancel=true, private=<unavailable>, abstime=0x00007fff991e8730, clockid=<unavailable>, expected=0, futex_word=0x00007fff6c00e810) at futex-internal.c:87:9
    frame #2: 0x00007ffff2e98d20 libc.so.6`__GI___futex_abstimed_wait_cancelable64(futex_word=0x00007fff6c00e810, expected=0, clockid=<unavailable>, abstime=0x00007fff991e8730, private=<unavailable>) at futex-internal.c:139:10
    frame #3: 0x00007ffff2e9bc8e libc.so.6`___pthread_cond_timedwait64 [inlined] __pthread_cond_wait_common(abstime=0x00007fff991e8730, clockid=0, mutex=0x00007fff6c00e7c0, cond=0x00007fff6c00e7e8) at pthread_cond_wait.c:503:10
    frame #4: 0x00007ffff2e9bb98 libc.so.6`___pthread_cond_timedwait64(cond=0x00007fff6c00e7e8, mutex=0x00007fff6c00e7c0, abstime=0x00007fff991e8730) at pthread_cond_wait.c:652:10
    frame #5: 0x00007fffa2a428a2 libjavascriptcoregtk-6.0.so.1`___lldb_unnamed_symbol43079 + 546
    frame #6: 0x00007ffff2e9caa4 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:447:8
    frame #7: 0x00007ffff2f29c3c libc.so.6`__clone3 at clone3.S:78
```
After dlclose():
```
* thread #18, name = 'gtest_host'
  * frame #0: 0x00007ffff2e98d71 libc.so.6`__GI___futex_abstimed_wait_cancelable64 [inlined] __futex_abstimed_wait_common64(private=<unavailable>, cancel=true, abstime=0x00007fff991e8730, op=393, expected=0, futex_word=0x00007fff6800e810) at futex-internal.c:57:12
    frame #1: 0x00007ffff2e98d47 libc.so.6`__GI___futex_abstimed_wait_cancelable64 [inlined] __futex_abstimed_wait_common(cancel=true, private=<unavailable>, abstime=0x00007fff991e8730, clockid=<unavailable>, expected=0, futex_word=0x00007fff6800e810) at futex-internal.c:87:9
    frame #2: 0x00007ffff2e98d20 libc.so.6`__GI___futex_abstimed_wait_cancelable64(futex_word=0x00007fff6800e810, expected=0, clockid=<unavailable>, abstime=0x00007fff991e8730, private=<unavailable>) at futex-internal.c:139:10
    frame #3: 0x00007ffff2e9bc8e libc.so.6`___pthread_cond_timedwait64 [inlined] __pthread_cond_wait_common(abstime=0x00007fff991e8730, clockid=0, mutex=0x00007fff6800e7c0, cond=0x00007fff6800e7e8) at pthread_cond_wait.c:503:10
    frame #4: 0x00007ffff2e9bb98 libc.so.6`___pthread_cond_timedwait64(cond=0x00007fff6800e7e8, mutex=0x00007fff6800e7c0, abstime=0x00007fff991e8730) at pthread_cond_wait.c:652:10
```
After a crash:
```
* thread #18, name = 'gtest_host', stop reason = signal SIGSEGV: address not mapped to object (fault address: 0x7fffa2a428a2)
  * frame #0: 0x00007fffa2a428a2
    frame #1: 0x00007fff991e8700
    frame #2: 0x00007ffff2e9caa4 libc.so.6`start_thread(arg=<unavailable>) at pthread_create.c:447:8
    frame #3: 0x00007ffff2f29c3c libc.so.6`__clone3 at clone3.S:78
```