### PR TITLE
cleanup: fix -Wmissing-braces warning in net_adapter_linux

### DIFF
--- a/net_adapter_linux.c
+++ b/net_adapter_linux.c
@@ -44,7 +44,8 @@ bool net_adapter_enum(void *user_data, net_adapter_cb callback) {
 
         int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
         if (fd) {
-            struct ifreq ifr = {0};
+            struct ifreq ifr;
+            memset(&ifr, 0, sizeof(ifr));
 
             ifr.ifr_ifindex = if_nametoindex(ifa->ifa_name);
 


### PR DESCRIPTION
## Summary

- Clang's `-Wmissing-braces` flagged `struct ifreq ifr = {0};` because the first member of `struct ifreq` is a union.
- Replaced with `memset`-based zero initialization, matching the existing style used four lines above for `adapter`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed initialization in Linux network adapter operations to prevent uninitialized state when querying interface details. This ensures more reliable detection of interface name, flags, and hardware address and reduces intermittent failures or incorrect results when enumerating network adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->